### PR TITLE
RF-13534 a4j:mediaOutput unauth. deserialisation

### DIFF
--- a/Modules/org/richfaces/main/module.xml
+++ b/Modules/org/richfaces/main/module.xml
@@ -16,5 +16,6 @@
         <module name="com.sun.jsf-impl" />
         <module name="javaee.api" />
         <module name="javax.faces.api" />
+        <module name="org.jboss.weld.core" />
     </dependencies>
 </module>


### PR DESCRIPTION
I got ClassNotFoundException on: org.jboss.weld.el.WeldMethodExpression

problem is described in https://issues.jboss.org/browse/RF-13534
RF-13534 a4j:mediaOutput on GF4: "Unauthorized deserialisation attempt"
